### PR TITLE
Fixed find by id method in app.rb

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -70,7 +70,7 @@ class MakersBnB < Sinatra::Base
 
   get '/postings/:id' do
     post_id = params[:id]
-    @post = Posting.find(post_id)
+    @post = Posting.find_by_id(post_id)
     @user = User.find_by_id(@post.user_id)
     erb :"postings/view_post"
   end


### PR DESCRIPTION
app.rb still contained old '#find' method instead of '#find_by_id'.  Live website was failing. View post spec file seems to be written correctly, so not sure how this slipped by.